### PR TITLE
chore: update devcontainer json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,6 +34,8 @@
         "python.languageServer": "Pylance",
         "python.analysis.typeCheckingMode": "basic",
         "ruff.showNotifications": "always",
+        // ruff.pathを指定することでVS Code拡張にバンドルされているruffではなくryeのruffを使用する
+        "ruff.path": ["/home/vscode/.rye/self/bin/ruff"],
         "vsintellicode.python.completionsEnabled": true,
         "vsintellicode.features.python.deepLearning": "enabled",
         "vsintellicode.modify.editor.suggestSelection": "enabled",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,15 +27,10 @@
             "path": "/bin/bash"
           }
         },
-        "black-formatter.args": ["--line-length", "100"],
-        "flake8.args": ["--config=.flake8"],
         "python.defaultInterpreterPath": "/project/.venv/bin/python",
         "python.pythonPath": "/project/.venv/bin/python",
-        "python.testing.unittestEnabled": false,
-        "python.testing.nosetestsEnabled": false,
         "python.testing.pytestEnabled": true,
         "python.analysis.diagnosticMode": "workspace",
-        "python.jediEnabled": false,
         "python.languageServer": "Pylance",
         "python.analysis.typeCheckingMode": "basic",
         "ruff.showNotifications": "always",
@@ -72,8 +67,6 @@
         "tamasfe.even-better-toml",
         "usernamehw.errorlens",
         "charliermarsh.ruff",
-        "ms-python.flake8",
-        "ms-python.black-formatter",
         "GitHub.copilot"
       ]
     }


### PR DESCRIPTION
ruff.pathについてはメモしておく。
コメントに書いてある通りruff.pathを指定することでVS Code拡張にバンドルされているruffではなくryeのruffを使用する。
VS Codeの拡張は最新版が入るようなので、ryeにバンドルされているものとバージョン差分がでてくる可能性がある。
そして、この場合結構面倒なことになるので、ryeの方を使うようにしている。
